### PR TITLE
Test short-circuiting in expressions

### DIFF
--- a/tests/02_execution/00_fundamental/07_short_circuit/06_and_expr.zi
+++ b/tests/02_execution/00_fundamental/07_short_circuit/06_and_expr.zi
@@ -1,0 +1,31 @@
+use io
+
+pred_lhs():bool
+{
+    printString("pred_lhs")
+    return false
+}
+
+pred_rhs():bool
+{
+    printString("pred_rhs")
+    return false
+}
+
+main():int
+{
+    result:int = 3
+    b:bool = pred_lhs() and pred_rhs()
+
+    if b {
+        result = 1
+    } else {
+        result = 0
+    }
+
+    return result
+}
+
+//@PRACOWNIA
+//@out pred_lhs
+//@out Exit code: 0

--- a/tests/02_execution/00_fundamental/07_short_circuit/07_or_expr.zi
+++ b/tests/02_execution/00_fundamental/07_short_circuit/07_or_expr.zi
@@ -1,0 +1,30 @@
+use io
+
+pred_lhs():bool
+{
+    printString("pred_lhs")
+    return true
+}
+
+pred_rhs():bool
+{
+    printString("pred_rhs")
+    return false
+}
+
+main():int
+{
+    result:int = 3
+    b:bool = pred_lhs() or pred_rhs();
+    if b {
+        result = 1
+    } else {
+        result = 0
+    }
+
+    return result
+}
+
+//@PRACOWNIA
+//@out pred_lhs
+//@out Exit code: 1


### PR DESCRIPTION
Current tests don't test short-circuiting in expressions - only in conditions. This PR adds two tests which explicitly test for that.